### PR TITLE
App Fetch Results Error

### DIFF
--- a/addon/components/wsuf-sidebar.js
+++ b/addon/components/wsuf-sidebar.js
@@ -27,15 +27,15 @@ export default Component.extend({
     yield race([resp, timeout(30000)]);
     
     if (resp.isSuccessful) {
-        let apps = yield resp.json();
+      let apps = yield resp._result.json();
 
-        let appList = [];
+      let appList = [];
 
-        for (let i = 0; i < apps.length; i++) {
-            appList.addObject(apps[i]);
-            context.set('apps', appList);
-            yield timeout(100);
-        }
+      for (let i = 0; i < apps.length; i++) {
+          appList.addObject(apps[i]);
+          context.set('apps', appList);
+          yield timeout(100);
+      }
     }
     else {
         resp.cancel();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsuf-sidebar",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
When the fetch call was wrapped in a ember-concurrency task, the call to get the response json was never updated. We now take the _results and get the json of the response.

Fixes Issue #2 